### PR TITLE
Fixed the LPF and changed the sample rate of the ADC

### DIFF
--- a/configuration.xml
+++ b/configuration.xml
@@ -673,12 +673,12 @@
       <property id="module.driver.timer.name" value="g_timer1"/>
       <property id="module.driver.timer.channel" value="1"/>
       <property id="module.driver.timer.mode" value="module.driver.timer.mode.mode_periodic"/>
-      <property id="module.driver.timer.period" value="50"/>
+      <property id="module.driver.timer.period" value="48828"/>
       <property id="module.driver.timer.compare_match.a.status" value="module.driver.timer.compare_match.a.status.disabled"/>
       <property id="module.driver.timer.compare_match.a.value" value="0"/>
       <property id="module.driver.timer.compare_match.b.status" value="module.driver.timer.compare_match.b.status.disabled"/>
       <property id="module.driver.timer.compare_match.b.value" value="0"/>
-      <property id="module.driver.timer.unit" value="module.driver.timer.unit.unit_period_usec"/>
+      <property id="module.driver.timer.unit" value="module.driver.timer.unit.unit_period_nsec"/>
       <property id="module.driver.timer.gtior.gtioa.initial_output_level" value="module.driver.timer.gtior.gtioa.initial_output_level.low"/>
       <property id="module.driver.timer.gtior.gtioa.cycle_end_output_level" value="module.driver.timer.gtior.gtioa.cycle_end_output_level.retain"/>
       <property id="module.driver.timer.gtior.gtioa.compare_match_output_level" value="module.driver.timer.gtior.gtioa.compare_match_output_level.retain"/>

--- a/src/fft_thread_entry.c
+++ b/src/fft_thread_entry.c
@@ -190,7 +190,7 @@ void fft_thread_entry(void *pvParameters)
             #endif
 
             // Filter input signal
-            fir_f32(real_input_signal_f32, filtered_output_f32);
+            fir_f32(real_input_signal_copy_f32, filtered_output_f32);
             #ifdef INSTRUCTION_BENCH
             ts_filter = DWT->CYCCNT;
             #endif


### PR DESCRIPTION
This PR fixes the issue with the filtered signal and the filtered FFT. It also changes the period of the timer so that the sample rate of the ADC is 20480 Hz instead of 20k Hz. This will cause the frequency bins of the FFT to be 20 Hz instead of some irrational number.